### PR TITLE
Specify type 'd' when using find

### DIFF
--- a/checker.py
+++ b/checker.py
@@ -191,6 +191,8 @@ def git_checker(
             check_dir,  # directory to look in (default: home)
             '-name',  # search by name
             '.git',
+            '-type',  # specify type
+            'd'
         ],  # the name we want
         stdout=sp.PIPE,  # catch output
         stderr=dn,  # send errors to the void!


### PR DESCRIPTION
Without using -type d, find will also pick up a file named .git, which will result in a crash as git_checker() assumes that nobody has such a file.

Without this fix, the following happens:

```
$ cd
$ mkdir tmp
$ cd tmp
$ touch .git
$ cd <path to git-checker>
$ python checker.py
fatal: invalid gitfile format: /home/evnu/tmp/.git
Traceback (most recent call last):
  File "checker.py", line 400, in <module>
    main()
  File "checker.py", line 396, in main
    checker(args.check_dir, REPORT_TRANSLATION[args.report_choice], args.check_home)
  File "checker.py", line 270, in checker
    git_report, n_dirty, n_unpushed = git_checker(git_check_dir, report_choices)
  File "checker.py", line 226, in git_checker
    if not check_clean(lines):
  File "checker.py", line 307, in check_clean
    last_line = status[-1]
IndexError: list index out of range
```